### PR TITLE
Add documentation and improve speed of test

### DIFF
--- a/dht/address.go
+++ b/dht/address.go
@@ -20,21 +20,27 @@ import (
 const AddressBinarySize = 20
 const AddressVersion = 0
 
+// Raw is 20 bytes. It is the BLAKE2(SHA3(publicKey)), with the blake2
+// digest size set to 20 bytes.
+// Encoded contains zif address.
 type Address struct {
 	Raw     []byte
 	Encoded string
 }
 
 // Generates an Address from a PublicKey.
-func NewAddress(key []byte) (addr Address) {
-	addr = Address{}
+func NewAddress(key []byte) (Address, error) {
+	addr := Address{}
 	addr.Generate(key)
 
-	return
+	_, err := addr.String()
+
+	return addr, err
 }
 
 // Returns Address.Bytes Base58 encoded and prepended with a Z.
 // Base58 removes ambiguous characters, reducing the chances of address confusion.
+// Address.Encoded will be set if not already. Otherwise it's current value is returned.
 func (a *Address) String() (string, error) {
 	if len(a.Encoded) > 0 {
 		return a.Encoded, nil

--- a/dht/netdb.go
+++ b/dht/netdb.go
@@ -306,6 +306,7 @@ func (ndb *NetDB) InsertSeed(entry Address, seed Address) error {
 }
 
 // Inserts an entry into both the routing table and the database
+// Returns number of affected entries and error
 func (ndb *NetDB) Insert(entry Entry) (int64, error) {
 	err := entry.Verify()
 

--- a/dht/netdb_test.go
+++ b/dht/netdb_test.go
@@ -146,17 +146,18 @@ func TestNetDBInsertAndLen(t *testing.T) {
 }
 
 func TestInsert(t *testing.T) {
-	num := 200
 	db := dbWithRandomAddress(t)
 
-	for i := 0; i < num; i++ {
-		entry := randomEntry(t)
+	entry := randomEntry(t)
 
-		db.Insert(entry)
+	_, err := db.Insert(entry)
 
-		if l, _ := db.Len(); l != i+1 {
-			t.Fatalf("Insert failed, len: %d, num: %d", l, num)
-		}
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if l, _ := db.Len(); l != 1 {
+		t.Fatalf("Insert failed, database len: %d", l)
 	}
 }
 


### PR DESCRIPTION
Insert test took a while to run. No documentation on what insert returns, that has been added.
Also, encoded zif address was not set in some cases, it will now always be set.